### PR TITLE
Validate image with EC

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,3 +82,13 @@ signed, it has an assocaited SLSA Provenance attestation, and more. Use the scri
 [check.sh](policy/check.sh) for this.
 
 NOTE: Modify the ruleData in [config.yaml](policy/config.yaml) to see what a failure looks like.
+
+The image signatures that EC verifies are [Sigstore](https://www.sigstore.dev/) based signatures.
+There are [different ways](https://blog.sigstore.dev/adopting-sigstore-incrementally-1b56a69b8c15/)
+of using Sigstore. For simplicity sake, the test model image built from this repo was signed with a
+long-lived key without Rekor integration. This means that we need to provide the public key when
+validating the image with EC. Furthermore, the *private* key is never really stored anywhere. So if
+running through the process of building the image again, a new key pair will be created. As such,
+update the public key in the [check.sh](policy/check.sh) script. The public key is referring to the
+file `cosign.pub` when executing: `cosign generate-key-pair k8s://tekton-chains/signing-secrets`from
+the tutorial: <https://tekton.dev/docs/chains/signed-provenance-tutorial/#generate-a-key-pair>

--- a/README.md
+++ b/README.md
@@ -76,3 +76,9 @@ Notice how it is also possible to determine the exact dataset used during traini
 NOTE: `cosign download` does not verify the data has not been tampered with. It's good enough for
 exploratory work. Production workflows should always access this data via something like
 `cosign verify-attestation`.
+
+You can also use [Enterprise Contract](https://enterprisecontract.dev/) to verify the image is
+signed, it has an assocaited SLSA Provenance attestation, and more. Use the script
+[check.sh](policy/check.sh) for this.
+
+NOTE: Modify the ruleData in [config.yaml](policy/config.yaml) to see what a failure looks like.

--- a/policy/check.sh
+++ b/policy/check.sh
@@ -1,0 +1,31 @@
+#! /bin/bash
+set -euo pipefail
+
+IMAGE="${1:-quay.io/lucarval/demo-oml:latest}"
+
+echo "👷 Checking ${IMAGE}"
+
+cd "$(git rev-parse --show-toplevel)"
+
+export RULES="$(pwd)//policy/rules"
+
+# This is the public key used during testing with a kind cluster. It will need to be updated when
+# verifying an image other than the default one.
+PUBLIC_KEY='-----BEGIN PUBLIC KEY-----
+MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEQmnuZzvNkoDf9G/CqFbq5sYw2aK/
+LKLdobfjGnOSiq5k2L3lQXv+jNTkcDCgIUk1HZkkFd4TFvkzYxGlfs0EoQ==
+-----END PUBLIC KEY-----'
+
+config_path="$(mktemp --suffix .yaml)"
+
+# A bit of a hack here to facilitate developemtn and CI. The config.yaml can be used as is, but it
+# will use the policy rules already pushed to main.
+echo '📓 Policy config updated to use local rules:'
+< policy/config.yaml yq '.sources[0].policy[0] |= env(RULES)' | tee "${config_path}"
+
+# The flag --ignore-rekor is used because when the image was signed, Rekor was not enabled in
+# Chains. Without the flag EC will fail as a corresponding entry in Rekor will not be found.
+echo '🔍 Validating image with EC'
+ec validate image --ignore-rekor \
+    --policy "${config_path}" --public-key <(echo "${PUBLIC_KEY}") --image "${IMAGE}" \
+    --output text --show-successes

--- a/policy/check.sh
+++ b/policy/check.sh
@@ -10,7 +10,9 @@ cd "$(git rev-parse --show-toplevel)"
 export RULES="$(pwd)//policy/rules"
 
 # This is the public key used during testing with a kind cluster. It will need to be updated when
-# verifying an image other than the default one.
+# verifying an image other than the default one, i.e.: this is the content of `cosign.pub` when
+# executing: cosign generate-key-pair k8s://tekton-chains/signing-secrets from the tutorial:
+# https://tekton.dev/docs/chains/signed-provenance-tutorial/#generate-a-key-pair
 PUBLIC_KEY='-----BEGIN PUBLIC KEY-----
 MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEQmnuZzvNkoDf9G/CqFbq5sYw2aK/
 LKLdobfjGnOSiq5k2L3lQXv+jNTkcDCgIUk1HZkkFd4TFvkzYxGlfs0EoQ==

--- a/policy/config.yaml
+++ b/policy/config.yaml
@@ -1,0 +1,12 @@
+---
+sources:
+  - policy:
+      - github.com/tarilabs/demo20240704-mltrain-as-oci//policy/rules
+      - github.com/enterprise-contract/ec-policies//policy/lib
+      - github.com/enterprise-contract/ec-policies//policy/release/lib/
+    data:
+      - oci::quay.io/konflux-ci/tekton-catalog/data-acceptable-bundles:latest
+      - github.com/release-engineering/rhtap-ec-policy//data
+    ruleData:
+      allowed_dataset_prefixes:
+        - quay.io/mmortari/

--- a/policy/rules/dataset.rego
+++ b/policy/rules/dataset.rego
@@ -1,0 +1,48 @@
+#
+# METADATA
+# title: OML checks
+#
+package policy.dataset
+
+import rego.v1
+
+import data.lib
+
+# METADATA
+# title: Training dataset comes from permitted sources
+# description: >-
+#   Verify the dataset used during model training comes from a known set of trusted sources. The
+#   list of permitted sources can be customized by setting the `allowed_dataset_prefixes` list in
+#   the rule data.
+# custom:
+#   short_name: permitted
+#   failure_msg: "%s"
+#
+deny contains result if {
+    some error in _errors
+	result := lib.result_helper(rego.metadata.chain(), [error])
+}
+
+_errors contains error if {
+    count(lib.results_named(_result_name)) == 0
+    error := sprintf("No results named %q found", [_result_name])
+}
+
+_errors contains error if {
+    count(lib.rule_data(_rule_data_key)) == 0
+    error := sprintf("Rule data %q not provided", [_rule_data_key])
+}
+
+_errors contains error if {
+    some result in lib.results_named(_result_name)
+    url := result.value
+    matches := [prefix |
+        some prefix in lib.rule_data(_rule_data_key)
+        startswith(url, prefix)
+    ]
+    count(matches) == 0
+    error := sprintf("Dataset URL %q is not allowed", [url])
+}
+
+_result_name = "DATASET_URL"
+_rule_data_key = "allowed_dataset_prefixes"


### PR DESCRIPTION
This commit adds instructions on how to use Enterprise Contract to validate the model image. In addition to the usual signature checks, a policy rule is used to verify the dataset used comes from a permitted source.